### PR TITLE
AtlNativeWindow: Add OLE control for completeness

### DIFF
--- a/AtlNativeWindow/AtlNativeWindow.vcxproj
+++ b/AtlNativeWindow/AtlNativeWindow.vcxproj
@@ -50,6 +50,9 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Manifest>
+      <AdditionalManifestFiles>$(OutDir)\MfcOleControl.dll.manifest</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -63,6 +66,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Manifest>
+      <AdditionalManifestFiles>$(OutDir)\MfcOleControl.dll.manifest</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Main.cpp" />


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3ad6137f-d49c-45a5-8030-45cd66d813aa)

Detected issue:
* #9 WS_EXT_LAYERED window is not transparent on first rendering.